### PR TITLE
stop mysqld_safe and wait the end of PID

### DIFF
--- a/root/etc/e-smith/events/actions/mysql-load-tables
+++ b/root/etc/e-smith/events/actions/mysql-load-tables
@@ -58,8 +58,7 @@ newpass=$(cat /var/lib/nethserver/secrets/mysql)
 /usr/bin/mysql mysql -u root -e "update user set password=PASSWORD(\"$newpass\") where User='root'; flush privileges;"
 
 # Stop all mysql instances
-/usr/bin/killall mysqld
-sleep 1
+/usr/bin/mysqladmin shutdown
 
 # restart mysqld as normal daemon
 /usr/bin/systemctl restart mysqld


### PR DESCRIPTION
better than to 'killall' mysqld service and wait an arbitrary time