### PR TITLE
Fix for NethVoice 14 restore config

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-mysql-restore-config
+++ b/root/etc/e-smith/events/actions/nethserver-mysql-restore-config
@@ -21,8 +21,9 @@
 #
 
 if [[ ! -f /var/lib/mysql/mysql/user.frm ]]; then 
-   # mysql is not configured, nothing to do
-   exit 0
+   # mysql is not configured do it now!
+   echo "[NOTICE] starting mysql initial configuration"
+   exec /etc/e-smith/events/actions/nethserver-mysql-conf
 fi
 
 echo "[NOTICE] restoring mysql root password"


### PR DESCRIPTION
Initialize mysql DB and restore root password

The mysqld.service must be running before the interface-update event,
as it can be required by other services during the restore-config procedure.

https://github.com/nethesis/dev/issues/5885